### PR TITLE
Use screen instead of cu

### DIFF
--- a/1.Getting Started.html
+++ b/1.Getting Started.html
@@ -54,11 +54,12 @@
 		<li>Plug the serial adapter into your computer. You can find the serial adapter via <code>dmesg | grep ttyUSB</code>, it will normally be /dev/ttyUSB0.
 		</li>
 		<li>Open a terminal session and connect to the serial port:<br>
-		  Linux/OSX: <code>cu -s 9600 -l /dev/ttyUSB0</code>
+		  Linux: <code>screen /dev/ttyUSB0 9600</code><br>
+		  OSX: <code>screen /dev/tty.SLAB_USBtoUART 9600</code><br>
 		  Windows: Use Putty to open a 9600 baud serial connection.</li>
 		<li>Reconnect the SWD programmer to power the board.</li>
 		<li>You should see the microcontroller report "Blink" on each loop.</li>
-		<li>You can terminate the serial connection by typing '~.'</li>
+		<li>You can terminate the serial connection by typing <code>Ctrl-A k y</code></li>
 	</ul>
 	<br>
 	<p>


### PR DESCRIPTION
`cu` needs a lot of messing around with `uucp` that doesn't work great on OSX:

```
$ cu -s 9600 -l /dev/tty.SLAB_USBtoUART
cu: creat during lock (/var/spool/uucp/TMP000000981d in /Users/michael/dev/logicanalyser_workshop as uid 501): Permission denied
cu: /dev/tty.SLAB_USBtoUART: Line in use
```

The lock directory is only owned by `_uucp`.  However, we don't use any fancy features in `cu`.

By comparison, `screen` pretty much "just works".